### PR TITLE
Revert "CRM-19665 WordPress: set canonical URL when using basepage  Add suppo…"

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -85,9 +85,6 @@ class CiviCRM_For_WordPress_Basepage {
     // And also for All in One SEO to handle canonical URL
     add_filter( 'aioseop_canonical_url', array( $this, 'basepage_canonical_url' ), 999 );
 
-    // All in One SEO has separate way of establishing canonical URL
-    add_filter( 'aioseop_canonical_url', array($this, 'basepage_canonical_url' ), 999);
-
     // regardless of URL, load page template
     add_filter( 'template_include', array( $this, 'basepage_template' ), 999 );
 


### PR DESCRIPTION
@kcristiano I forgot that I had seen your suggestion but not your PR, so the merge wasn't necessary (and caused the filter to be added twice).